### PR TITLE
Fix build on Fedora with ffmpeg 4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore CLion IDE specific stuff:
+.idea/
+*.iml
+
+# Ignore generated files and compiler output:
+.qmake.stash
+Makefile
+moc_*
+*.o
+
+# Ignore the binary
+Qtcam

--- a/INSTALL
+++ b/INSTALL
@@ -99,8 +99,8 @@ Then double click the downloaded binary and install it to your local system.
   In ubuntu 20.04,
  $sudo apt-get install libv4l-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavresample-dev libudev-dev libavcodec-extra qt5-default qtdeclarative5-dev freeglut3 freeglut3-dev libjpeg-turbo8-dev libusb-1.0-0-dev libusb-dev libevdev-dev libpulse-dev qtmultimedia5-dev qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-extras qml-module-qtquick-privatewidgets libasound2-dev libturbojpeg0-dev qtquickcontrols5-doc g++ g++-10 lsb-release
 
- In Fedora 29,
- $ sudo dnf install -y libv4l-devel qt5-devel qtav-devel systemd-devel libusb-devel turbojpeg-devel ffmpeg-devel libevdev-devel
+ In Fedora 40,
+ $ sudo dnf install -y libv4l-devel qt5-qtbase-devel qt5-qtquickcontrols2-devel qt5-qtmultimedia-devel qtav-devel systemd-devel libusb1-devel turbojpeg-devel ffmpeg-devel libevdev-devel
 
 
 3.3 Build the application

--- a/INSTALL
+++ b/INSTALL
@@ -91,13 +91,16 @@ Then double click the downloaded binary and install it to your local system.
  $ sudo apt-get install libv4l-dev qt55base qt55declarative libavcodec-dev libgl1-mesa-dev libglu1-mesa-dev libavformat-dev libavutil-dev libswscale-dev libavresample-dev libudev-dev libavcodec-extra-54 libjpeg-turbo8-dev libusb-1.0-0-dev libusb-dev libevdev-dev  libpulse-dev qt55multimedia qtdeclarative5-window-plugin qtdeclarative5-dialogs-plugin qtdeclarative5-controls-plugin  qtdeclarative5-qtquick2-plugin qt55-meta-full libasound2-dev
 
  In ubuntu 16.04,
- $ sudo apt-get install libv4l-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavresample-dev libudev-dev libavcodec-extra qt5-default qtdeclarative5-dev freeglut3 freeglut3-dev libjpeg-turbo8-dev libusb-1.0-0-dev libusb-dev libevdev-dev libpulse-dev qtmultimedia5-dev qtdeclarative5-window-plugin qtdeclarative5-dialogs-plugin qtdeclarative5-controls-plugin  qtdeclarative5-qtquick2-plugin qtdeclarative5-qtmultimedia-plugin libasound2-dev 
+ $ sudo apt-get install libv4l-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavresample-dev libudev-dev libavcodec-extra qt5-default qtdeclarative5-dev freeglut3 freeglut3-dev libjpeg-turbo8-dev libusb-1.0-0-dev libusb-dev libevdev-dev libpulse-dev qtmultimedia5-dev qtdeclarative5-window-plugin qtdeclarative5-dialogs-plugin qtdeclarative5-controls-plugin  qtdeclarative5-qtquick2-plugin qtdeclarative5-qtmultimedia-plugin libasound2-dev
 
  In ubuntu 18.04,
  $sudo apt-get install libv4l-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavresample-dev libudev-dev libavcodec-extra qt5-default qtdeclarative5-dev freeglut3 freeglut3-dev libjpeg-turbo8-dev libusb-1.0-0-dev libusb-dev libevdev-dev libpulse-dev qtmultimedia5-dev qtdeclarative5-window-plugin qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-extras qml-module-qtquick-privatewidgets qtdeclarative5-qtquick2-plugin libasound2-dev libturbojpeg0-dev qtquickcontrols5-doc g++-5 lsb-release
- 
+
   In ubuntu 20.04,
  $sudo apt-get install libv4l-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavresample-dev libudev-dev libavcodec-extra qt5-default qtdeclarative5-dev freeglut3 freeglut3-dev libjpeg-turbo8-dev libusb-1.0-0-dev libusb-dev libevdev-dev libpulse-dev qtmultimedia5-dev qml-module-qtquick-controls qml-module-qtquick-dialogs qml-module-qtquick-extras qml-module-qtquick-privatewidgets libasound2-dev libturbojpeg0-dev qtquickcontrols5-doc g++ g++-10 lsb-release
+
+ In Fedora 29,
+ $ sudo dnf install -y libv4l-devel qt5-devel qtav-devel systemd-devel libusb-devel turbojpeg-devel ffmpeg-devel libevdev-devel
 
 
 3.3 Build the application
@@ -118,7 +121,7 @@ You can build your application in two ways
 1.  Goto your git clone path.
 2.  cd src/
 3.  Set LAUNCHPAD macro in common.h to 0.
-4.  qmake,(For example, /home/@user/Qt5.9.1/5.9.1/gcc_64/bin/qmake)
+4.  qmake,(For example, /home/@user/Qt5.9.1/5.9.1/gcc_64/bin/qmake, or /usr/bin/qmake-qt5)
 5.  make clean
 6.  make
 7.  Execute the application.

--- a/src/qtcam.pro
+++ b/src/qtcam.pro
@@ -26,7 +26,7 @@ else:{
 QT += widgets concurrent multimedia
 TARGET = Qtcam
 
-CONFIG += release
+CONFIG += c++14 release
 
 # Additional import path used to resolve QML modules in Creator's code model
 QML_IMPORT_PATH =
@@ -179,9 +179,10 @@ HEADERS += \
 
 
 INCLUDEPATH +=  $$PWD/v4l2headers/include \
-                /usr/include \
+                /usr/include/ffmpeg \
                 /usr/include/libusb-1.0
 
+# why not use QMAKE_HOST.arch
 UNAME_MACHINE_32BIT = $$system(dpkg --print-architecture | grep -o "i386")
 UNAME_MACHINE_64BIT = $$system(dpkg --print-architecture | grep -o "amd64")
 BOARD_ARM64 = $$system(dpkg --print-architecture | grep -o "arm64")
@@ -194,7 +195,7 @@ QMAKE_CXXFLAGS += -std=c++11
 
 contains(UNAME_MACHINE_64BIT, amd64):{
     message("x86_64 bit libs")
-    LIBS += -lv4l2 -lv4lconvert \       
+    LIBS += -lv4l2 -lv4lconvert \
         -lavutil \
         -lavcodec \
         -lavformat \

--- a/src/qtcam.pro
+++ b/src/qtcam.pro
@@ -1,14 +1,16 @@
-# Check for the Ubuntu version and set appropriate flags
-ubuntu_version = $$system(lsb_release -rs)
+# Check for the Linux distro and set appropriate flags
+distro = $$system(lsb_release -rsd)
 
-equals(ubuntu_version, 16.04) {
+equals(distro, 16.04) {
     DEFINES += UBUNTU_16_04
-}else: equals(ubuntu_version, 18.04) {
+}else: equals(distro, 18.04) {
     DEFINES += UBUNTU_18_04
-} else: equals(ubuntu_version, 20.04) {
+} else: equals(distro, 20.04) {
     DEFINES += UBUNTU_20_04
-} else: equals(ubuntu_version, 22.04) {
+} else: equals(distro, 22.04) {
     DEFINES += UBUNTU_22_04
+} else: equals(distro, Fedora) {
+    DEFINES += FEDORA
 }
 
 contains(DEFINES, UBUNTU_22_04) {
@@ -182,18 +184,13 @@ INCLUDEPATH +=  $$PWD/v4l2headers/include \
                 /usr/include/ffmpeg \
                 /usr/include/libusb-1.0
 
-# why not use QMAKE_HOST.arch
-UNAME_MACHINE_32BIT = $$system(dpkg --print-architecture | grep -o "i386")
-UNAME_MACHINE_64BIT = $$system(dpkg --print-architecture | grep -o "amd64")
-BOARD_ARM64 = $$system(dpkg --print-architecture | grep -o "arm64")
-
 DISTRIBUTION_NAME = $$system(lsb_release -a | grep -o "bionic")
-contains(DISTRIBUTION_NAME,bionic):{
-QMAKE_CXX = "g++-5"
-QMAKE_CXXFLAGS += -std=c++11
+contains(DISTRIBUTION_NAME, bionic):{
+    QMAKE_CXX = "g++-5"
+    QMAKE_CXXFLAGS += -std=c++11
 }
 
-contains(UNAME_MACHINE_64BIT, amd64):{
+contains(QMAKE_HOST.arch, amd64):{
     message("x86_64 bit libs")
     LIBS += -lv4l2 -lv4lconvert \
         -lavutil \
@@ -208,7 +205,7 @@ contains(UNAME_MACHINE_64BIT, amd64):{
         -L/usr/lib/x86_64-linux-gnu/ -levdev
 }
 
-contains(UNAME_MACHINE_32BIT, i386):{
+contains(QMAKE_HOST.arch, i386):{
     message("x86_32 bit libs")
     LIBS += -lv4l2 -lv4lconvert \
         -lavutil \
@@ -223,7 +220,7 @@ contains(UNAME_MACHINE_32BIT, i386):{
         -L/usr/lib/i386-linux-gnu/ -levdev
 }
 
-contains(BOARD_ARM64, arm64):{
+contains(QMAKE_HOST.arch, arm64):{
     message("Arm64 libs")
     LIBS += -lv4l2 -lv4lconvert \
         -lavutil \

--- a/src/videoencoder.cpp
+++ b/src/videoencoder.cpp
@@ -137,7 +137,7 @@ bool VideoEncoder::createFile(QString fileName,CodecID encodeType, unsigned widt
         pCodecCtx=pVideoStream->codec;
         // some formats want stream headers to be separate
         if(pFormatCtx->oformat->flags & AVFMT_GLOBALHEADER)
-            pCodecCtx->flags |= CODEC_FLAG_GLOBAL_HEADER;
+            pCodecCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
         pCodecCtx->codec_id = pOutputFormat->video_codec;
 


### PR DESCRIPTION
this PR addresses 2 problems:

- The qmake build assumes Ubuntu is being used when detecting cpu type (`QMAKE_HOST.arch` is far better option anyway)
- Some minor changes were needed to compile with more recent ffmpeg libs

These changes got it building for me on Fedora 29